### PR TITLE
enable csrf cookie

### DIFF
--- a/src/main/java/io/demo/conf/security/SecurityConfig.java
+++ b/src/main/java/io/demo/conf/security/SecurityConfig.java
@@ -27,6 +27,7 @@ import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @EnableWebSecurity
 @ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
@@ -51,7 +52,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		super.configure(http);
-		http.csrf().disable();
+		http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
 		http.cors();
 		http.headers().frameOptions().sameOrigin();
 		if (metaConfigurationProperties.isDevPanelEnabled()) {


### PR DESCRIPTION
[CSRF](https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/csrf.html)

To enable CSRF protection Tesler application should send "XSRF-TOKEN", which is then automatically read by axios client used for ajax requests by Tesler UI to include this token as `X-XSRF-TOKEN` http header

`XSRF-TOKEN` and `X-XSRF-TOKEN` are [default names]( https://github.com/axios/axios/blob/76f09afc03fbcf392d31ce88448246bcd4f91f8c/lib/defaults.js#L109) for cookie and http header both for axios and spring security

