### PR TITLE
Changed the logic of displaying widgets on one line

### DIFF
--- a/src/main/resources/db/changelog/0000300_tesler_core.xml
+++ b/src/main/resources/db/changelog/0000300_tesler_core.xml
@@ -751,7 +751,7 @@
       <column name="DESCRIPTION" type="CLOB"/>
       <column name="SNIPPET" type="CLOB"/>
       <column name="PAGE_LIMIT" remarks="Лимит" type="NUMBER(10, 0)"/>
-      <column defaultValueNumeric="1" name="GRID_WIDTH" type="NUMBER(1, 0)">
+      <column defaultValueNumeric="1" name="GRID_WIDTH" type="NUMBER(2, 0)">
         <constraints nullable="false"/>
       </column>
       <column defaultValueNumeric="0" name="GRID_BREAK" type="NUMBER(1, 0)">

--- a/src/main/resources/meta/screen/client/view/clientedit.view.json
+++ b/src/main/resources/meta/screen/client/view/clientedit.view.json
@@ -7,22 +7,22 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEdit",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactEditList",
       "position": 3,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/client/view/clienteditcontacts.view.json
+++ b/src/main/resources/meta/screen/client/view/clienteditcontacts.view.json
@@ -7,27 +7,27 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditStep",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactEditList",
       "position": 3,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditButtons",
       "position": 5,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactListAssoc",
       "position": 6,
-      "gridWidth": 1
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/client/view/clienteditcreatecontact.view.json
+++ b/src/main/resources/meta/screen/client/view/clienteditcreatecontact.view.json
@@ -7,16 +7,16 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },{
       "widgetName": "clientContactEdit",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactEditForm",
       "position": 5,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/client/view/clienteditgeneral.view.json
+++ b/src/main/resources/meta/screen/client/view/clienteditgeneral.view.json
@@ -7,22 +7,22 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditStep",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEdit",
       "position": 3,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/client/view/clienteditoverview.view.json
+++ b/src/main/resources/meta/screen/client/view/clienteditoverview.view.json
@@ -7,37 +7,37 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditStep",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientViewHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientView",
       "position": 3,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactListHeader",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactViewList",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientEditButtons",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/client/view/clientlist.view.json
+++ b/src/main/resources/meta/screen/client/view/clientlist.view.json
@@ -7,12 +7,12 @@
     {
       "widgetName": "clientListHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientList",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/client/view/clientview.view.json
+++ b/src/main/resources/meta/screen/client/view/clientview.view.json
@@ -7,32 +7,32 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientViewHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientViewOperations",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "clientView",
       "position": 3,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactListHeader",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "contactViewList",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/meeting/view/meetingedit.view.json
+++ b/src/main/resources/meta/screen/meeting/view/meetingedit.view.json
@@ -7,42 +7,42 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingEditHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingEdit",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingClientInfo",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingResultEdit",
       "position": 5,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "responsiblePickListPopup",
       "position": 1,
-      "gridWidth": 2
+      "gridWidth": 24
     },
      {
        "widgetName": "clientPickListPopup",
        "position": 1,
-       "gridWidth": 2
+       "gridWidth": 24
      },
      {
        "widgetName": "contactPickListPopup",
        "position": 1,
-       "gridWidth": 2
+       "gridWidth": 24
      }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/meeting/view/meetinglist.view.json
+++ b/src/main/resources/meta/screen/meeting/view/meetinglist.view.json
@@ -7,12 +7,12 @@
     {
       "widgetName": "meetingListHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingList",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/src/main/resources/meta/screen/meeting/view/meetingview.view.json
+++ b/src/main/resources/meta/screen/meeting/view/meetingview.view.json
@@ -7,32 +7,32 @@
     {
       "widgetName": "SecondLevelMenu",
       "position": 0,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingViewHeader",
       "position": 1,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingViewButtons",
       "position": 2,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingView",
       "position": 3,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingViewClientInfo",
       "position": 4,
-      "gridWidth": 4
+      "gridWidth": 24
     },
     {
       "widgetName": "meetingViewResult",
       "position": 5,
-      "gridWidth": 4
+      "gridWidth": 24
     }
   ],
   "rolesAllowed": [

--- a/ui/src/components/View/View.tsx
+++ b/ui/src/components/View/View.tsx
@@ -15,6 +15,7 @@ import Table from '../widgets/Table/Table'
 import { FieldType } from '@tesler-ui/core/interfaces/view'
 import Dictionary from '../../fields/Dictionary/Dictionary'
 import Steps from '../widgets/Steps/Steps'
+import { DashboardLayout } from '../ui/DashboardLayout/DashboardLayout'
 
 const skipWidgetTypes = [WidgetTypes.SecondLevelMenu]
 
@@ -41,6 +42,7 @@ function View() {
                 customFields={customFields}
                 card={Card as any}
                 skipWidgetTypes={skipWidgetTypes}
+                customLayout={DashboardLayout}
             />
         </div>
     )

--- a/ui/src/components/ui/DashboardLayout/DashboardLayout.tsx
+++ b/ui/src/components/ui/DashboardLayout/DashboardLayout.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Row, Col } from 'antd'
+import { CustomWidgetDescriptor, WidgetMeta } from '../../../../../../tesler-ui/dist/interfaces/widget'
+import { Widget } from '@tesler-ui/core'
+
+export interface DashboardLayoutProps {
+    widgets: WidgetMeta[]
+    customWidgets?: Record<string, CustomWidgetDescriptor>
+    skipWidgetTypes?: string[]
+    customSpinner?: (props: any) => React.ReactElement<any>
+    card?: (props: any) => React.ReactElement<any>
+}
+
+export function DashboardLayout(props: DashboardLayoutProps) {
+    const widgetsByRow = React.useMemo(() => {
+        return groupByRow(props.widgets, props.skipWidgetTypes || [])
+    }, [props.widgets, props.skipWidgetTypes])
+    return (
+        <React.Fragment>
+            {Object.values(widgetsByRow).map((row, rowIndex) => (
+                <Row key={rowIndex}>
+                    {row.map((widget, colIndex) => (
+                        <Col key={colIndex} span={widget.gridWidth}>
+                            <Widget
+                                meta={widget}
+                                card={props.card}
+                                customWidgets={props.customWidgets}
+                                customSpinner={props.customSpinner}
+                            />
+                        </Col>
+                    ))}
+                </Row>
+            ))}
+        </React.Fragment>
+    )
+}
+
+function groupByRow(widgets: WidgetMeta[], skipWidgetTypes: string[]) {
+    const byRow: Record<string, WidgetMeta[]> = {}
+    widgets
+        .filter(item => {
+            return !skipWidgetTypes.includes(item.type)
+        })
+        .forEach(item => {
+            if (!byRow[item.position]) {
+                byRow[item.position] = []
+            }
+            byRow[item.position].push(item)
+        })
+    return byRow
+}
+
+export const MemoizedDashboard = React.memo(DashboardLayout)
+
+export default MemoizedDashboard


### PR DESCRIPTION
Changed the logic of displaying widgets on one line. The width is set by setting "gridWidth" in view.meta. Maximum width of 24 if we want to fit two widgets on one line put the same value of "position" and the sum of the "gridWidth" of the two widgets should not exceed 24

example


<img width="203" alt="tesler-demo-view" src="https://user-images.githubusercontent.com/35976320/160889482-d82a319e-d682-420c-b534-4308448d67b9.PNG">

